### PR TITLE
Support ruby 3 keyword args

### DIFF
--- a/lib/active_record_postgresql_xverify/error_handler.rb
+++ b/lib/active_record_postgresql_xverify/error_handler.rb
@@ -9,7 +9,7 @@ module ActiveRecordPostgresqlXverify
       raise
     end
 
-    def execute_and_clear(*)
+    def execute_and_clear(*, **)
       super
     rescue StandardError
       _flag_extend_verify!


### PR DESCRIPTION
This avoids the `Using the last argument as keyword parameters is deprecated` message.

```
/Users/fakiyer/src/github.com/fakiyer/active_record_postgresql_xverify/lib/active_record_postgresql_xverify/error_handler.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```